### PR TITLE
Move Mobile Navigation from Avatar Menu to a New Dedicated Menu 

### DIFF
--- a/src/components/brand/Logo.svelte
+++ b/src/components/brand/Logo.svelte
@@ -1,11 +1,10 @@
-<div class="">
-	<p id="logo">ResqiAR</p>
+<div>
+	<p id="logo" class="text-[24px] lg:text-[32px]">ResqiAR</p>
 </div>
 
 <style>
 	#logo {
 		margin: 0;
-		font-size: 32px;
 		font-family: 'Righteous', 'Roboto';
 		background: linear-gradient(90deg, #4e004f 1%, rgba(255, 144, 0, 1) 75%);
 		/* background: rgba(255, 144, 0, 1); */

--- a/src/components/header/MainHeader.svelte
+++ b/src/components/header/MainHeader.svelte
@@ -3,6 +3,7 @@
 
 	import Logo from '../brand/Logo.svelte';
 	import MainMenu from '../menu/MainMenu.svelte';
+	import MobileNavigation from '../menu/MobileNavigation.svelte';
 	import ThemeChangeMenu from '../menu/ThemeChangeMenu.svelte';
 
 	export let active: number = 0;
@@ -82,7 +83,7 @@
 			target="_blank"
 			aria-label="Author's GitHub"
 			title="Author's GitHub"
-			class="btn-ghost btn-square btn"
+			class="btn-ghost btn-square btn hidden lg:flex"
 			rel="noreferrer"
 		>
 			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
@@ -95,5 +96,8 @@
 
 		<!-- THEME CHANGE MENU -->
 		<ThemeChangeMenu />
+
+		<!-- MOBILE NAVIGATION -->
+		<MobileNavigation />
 	</div>
 </div>

--- a/src/components/menu/MainMenu.svelte
+++ b/src/components/menu/MainMenu.svelte
@@ -3,68 +3,6 @@
 	tabindex="-1"
 	class="dropdown-content menu rounded-box w-52 bg-base-200 p-2 shadow-2xl"
 >
-	<li class="flex lg:hidden">
-		<a href="/">
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke-width="1.5"
-				stroke="currentColor"
-				class="h-6 w-6"
-			>
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
-				/>
-			</svg>
-			Dashboard</a
-		>
-	</li>
-
-	<li class="flex lg:hidden">
-		<a href="/blog">
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke-width="1.5"
-				stroke="currentColor"
-				class="h-6 w-6"
-			>
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 01-2.25 2.25M16.5 7.5V18a2.25 2.25 0 002.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 002.25 2.25h13.5M6 7.5h3v3H6v-3z"
-				/>
-			</svg>
-			Blog</a
-		>
-	</li>
-
-	<li class="flex lg:hidden">
-		<a href="/playground">
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke-width="1.5"
-				stroke="currentColor"
-				class="h-6 w-6"
-			>
-				<path
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z"
-				/>
-			</svg>
-			Playground</a
-		>
-	</li>
-
-	<div class="divider my-0 flex before:bg-base-300 after:bg-base-300 lg:hidden" />
-
 	<li>
 		<a href="/blog/manage">
 			<svg

--- a/src/components/menu/MobileNavigation.svelte
+++ b/src/components/menu/MobileNavigation.svelte
@@ -1,0 +1,84 @@
+<div class="dropdown-bottom dropdown-end dropdown flex lg:hidden">
+	<label tabindex="-1" class="btn-ghost btn-square btn" for="mobile-dropdown">
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke-width="1.5"
+			stroke="currentColor"
+			class="h-6 w-6"
+		>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+			/>
+		</svg>
+	</label>
+
+	<ul
+		id="mobile-dropdown"
+		tabindex="-1"
+		class="dropdown-content menu rounded-box w-52 bg-base-200 p-2 shadow-2xl"
+	>
+		<li class="flex lg:hidden">
+			<a href="/">
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke-width="1.5"
+					stroke="currentColor"
+					class="h-6 w-6"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+					/>
+				</svg>
+				Dashboard</a
+			>
+		</li>
+
+		<li class="flex lg:hidden">
+			<a href="/blog">
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke-width="1.5"
+					stroke="currentColor"
+					class="h-6 w-6"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 01-2.25 2.25M16.5 7.5V18a2.25 2.25 0 002.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 002.25 2.25h13.5M6 7.5h3v3H6v-3z"
+					/>
+				</svg>
+				Blog</a
+			>
+		</li>
+
+		<li class="flex lg:hidden">
+			<a href="/playground">
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke-width="1.5"
+					stroke="currentColor"
+					class="h-6 w-6"
+				>
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z"
+					/>
+				</svg>
+				Playground</a
+			>
+		</li>
+	</ul>
+</div>


### PR DESCRIPTION
Just like the title, this PR moves the navigation from only logged-in component to a new universal component. This way all users have the right to access the navigation when on mobile.
This PR also reduce the size of the Logo when on mobile.