### PR TITLE
Multiple Language Translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "svelte": "^3.44.0",
     "svelte-carousel": "^1.0.25",
     "svelte-check": "^2.7.1",
+    "svelte-flag-icons": "^0.5.5",
     "svelte-preprocess": "^5.0.0",
     "tailwindcss": "^3.2.4",
     "tslib": "^2.3.1",

--- a/src/components/body/DetailBlogBody.svelte
+++ b/src/components/body/DetailBlogBody.svelte
@@ -5,6 +5,7 @@
 
 	// highlight.js StyleSheet
 	import '../../styles/highlighter/atom-one-dark.css';
+	import TranslationMenu from '../menu/TranslationMenu.svelte';
 
 	export let blog: ISafeBlogAuthor;
 </script>
@@ -67,7 +68,7 @@
 			</div>
 
 			<div>
-				<button disabled class="btn-ghost disabled btn-sm btn-circle btn lg:btn-md">
+				<button disabled class="disabled btn-ghost btn-sm btn-circle btn lg:btn-md">
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
 						fill="none"
@@ -84,7 +85,7 @@
 					</svg>
 				</button>
 
-				<button disabled class="btn-ghost disabled btn-sm btn-circle btn lg:btn-md">
+				<button disabled class="disabled btn-ghost btn-sm btn-circle btn lg:btn-md">
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
 						fill="none"
@@ -101,22 +102,8 @@
 					</svg>
 				</button>
 
-				<button disabled class="btn-ghost disabled btn-sm btn-circle btn lg:btn-md">
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke-width="1.5"
-						stroke="currentColor"
-						class="h-4 w-4 lg:h-6 lg:w-6"
-					>
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0111.186 0z"
-						/>
-					</svg>
-				</button>
+				<!-- TRANSLATION Menu -->
+				<TranslationMenu blogID={blog.ID} />
 			</div>
 		</div>
 

--- a/src/components/menu/TranslationMenu.svelte
+++ b/src/components/menu/TranslationMenu.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+	// @ts-nocheck
+	import Id from 'svelte-flag-icons/Id.svelte';
+	import Jp from 'svelte-flag-icons/Jp.svelte';
+	import Sa from 'svelte-flag-icons/Sa.svelte';
+
+	export let blogID: string;
+	const URL: string = `https://www-resqiar-com.translate.goog/blog/${blogID}?_x_tr_sl=en&_x_tr_tl=`;
+</script>
+
+<div class="dropdown-end dropdown">
+	<label tabindex="-1" class="btn-ghost btn-sm btn-circle btn lg:btn-md" for="translate-menu">
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			fill="none"
+			viewBox="0 0 24 24"
+			stroke-width="1.5"
+			stroke="currentColor"
+			class="h-4 w-4 lg:h-6 lg:w-6"
+		>
+			<path
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				d="M10.5 21l5.25-11.25L21 21m-9-3h7.5M3 5.621a48.474 48.474 0 016-.371m0 0c1.12 0 2.233.038 3.334.114M9 5.25V3m3.334 2.364C11.176 10.658 7.69 15.08 3 17.502m9.334-12.138c.896.061 1.785.147 2.666.257m-4.589 8.495a18.023 18.023 0 01-3.827-5.802"
+			/>
+		</svg>
+	</label>
+
+	<ul
+		id="translate-menu"
+		tabindex="-1"
+		class="dropdown-content menu rounded-box w-52 bg-base-200 p-2 shadow-2xl"
+	>
+		<!-- INDONESIAN / BAHASA -->
+		<li>
+			<a
+				href={URL + 'id'}
+				target="_blank"
+				referrerpolicy="no-referrer"
+				class="flex items-center gap-2"
+			>
+				<Id size="25" />
+				Read in Bahasa</a
+			>
+		</li>
+
+		<!-- JAPANESE -->
+		<li>
+			<a
+				href={URL + 'ja'}
+				target="_blank"
+				referrerpolicy="no-referrer"
+				class="flex items-center gap-2"
+			>
+				<Jp size="25" />
+				Read in Japanese</a
+			>
+		</li>
+
+		<!-- ARABIC -->
+		<li>
+			<a
+				href={URL + 'ar'}
+				target="_blank"
+				referrerpolicy="no-referrer"
+				class="flex items-center gap-2"
+			>
+				<Sa size="25" />
+				Read in Arabic</a
+			>
+		</li>
+
+		<li>
+			<a
+				href={URL + 'zh-TW'}
+				target="_blank"
+				referrerpolicy="no-referrer"
+				class="flex items-center gap-2"
+			>
+				Other Languages...</a
+			>
+		</li>
+	</ul>
+</div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,18 @@
 {
-	"extends": "./.svelte-kit/tsconfig.json",
-	"compilerOptions": {
-		"allowJs": true,
-		"checkJs": true,
-		"esModuleInterop": true,
-		"forceConsistentCasingInFileNames": true,
-		"resolveJsonModule": true,
-		"skipLibCheck": true,
-		"sourceMap": true,
-		"strict": true
-	}
-	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
-	//
-	// If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-	// from the referenced tsconfig.json - TypeScript does not merge them in
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+  // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
+  //
+  // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
+  // from the referenced tsconfig.json - TypeScript does not merge them in
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2910,6 +2910,11 @@ svelte-file-dropzone@^2.0.1:
   dependencies:
     file-selector "^0.2.4"
 
+svelte-flag-icons@^0.5.5:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/svelte-flag-icons/-/svelte-flag-icons-0.5.5.tgz#d574ee3af26e40f304a6aa387781da5ecbe40367"
+  integrity sha512-66mBHl8fQkkpmcFplYAedtJLHCj+rTC/i8XWxfESlk/b9CliyZjuP3RedJgj71US7NpwYmJMOiluCFoVJJKLZw==
+
 svelte-hmr@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.15.1.tgz#d11d878a0bbb12ec1cba030f580cd2049f4ec86b"


### PR DESCRIPTION
I discovered an interesting workaround using Google Translate, where a webpage can be translated by simply modifying the URL. For instance, the URL https://www-resqiar-com.translate.goog/blog/bZEXMBDUap0A?_x_tr_sl=en&_x_tr_tl=id demonstrates this approach. By redirecting the page to the Google Translate URL, we can achieve translation without the need for any backend modifications or reliance on the Google Translate API. This method offers a convenient alternative for translating webpages while bypassing the complexities of backend implementation and avoiding API consumption.