### PR TITLE
change public url to title slug instead of nanoid

### DIFF
--- a/src/components/body/ManageBlogBody.svelte
+++ b/src/components/body/ManageBlogBody.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import type { IBlog } from '../../types/Blog';
+	import type UserProfile from '../../types/UserProfile';
 	import ManageBlog404 from '../404/ManageBlog404.svelte';
 	import ManageBlogTable from '../tables/ManageBlogTable.svelte';
 
+	export let userProfile: UserProfile;
 	export let publishedBlogs: IBlog[];
 	export let draftedBlogs: IBlog[];
 	export let error: boolean;
@@ -68,7 +70,7 @@
 				<!-- IF IT CONTAINS VALUE  -->
 				{#if publishedBlogs.length}
 					<div class="flex w-full flex-col items-center justify-center gap-2 lg:flex-row">
-						<ManageBlogTable data={publishedBlogs} published {onDataChange} />
+						<ManageBlogTable {userProfile} data={publishedBlogs} published {onDataChange} />
 					</div>
 				{:else}
 					<!-- ELSE SHOW 404 -->
@@ -77,7 +79,7 @@
 				<!-- IF TAB INDEX IS NOT 0 && IT CONTAINS VALUE  -->
 			{:else if draftedBlogs.length}
 				<div class="flex w-full flex-col items-center justify-center gap-2 lg:flex-row">
-					<ManageBlogTable data={draftedBlogs} published={false} {onDataChange} />
+					<ManageBlogTable {userProfile} data={draftedBlogs} published={false} {onDataChange} />
 				</div>
 			{:else}
 				<!-- ELSE SHOW 404 -->

--- a/src/components/cards/BlogCard.svelte
+++ b/src/components/cards/BlogCard.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <a
-	href={`/blog/${item.ID}`}
+	href={`/blog/${item.Author.Username}/${item.Slug}`}
 	class="card h-min w-full flex-wrap bg-base-300 shadow-xl transition-all hover:-translate-y-1 hover:shadow-2xl lg:w-96"
 >
 	{#if item.CoverURL}
@@ -29,7 +29,7 @@
 						</div>
 					</div>
 				{:else}
-					<div class="placeholder avatar">
+					<div class="avatar placeholder">
 						<div class="w-10 rounded-full bg-neutral-focus text-neutral-content">
 							<span class="text-xl">{item.Author.Username[0]}</span>
 						</div>

--- a/src/components/tables/ManageBlogTable.svelte
+++ b/src/components/tables/ManageBlogTable.svelte
@@ -4,8 +4,10 @@
 	import type { ManageAction } from '../../data/modalActionState';
 	import type { IBlog } from '../../types/Blog';
 	import ManageModal from '../modal/ManageModal.svelte';
+	import type UserProfile from '../../types/UserProfile';
 
 	export let data: IBlog[];
+	export let userProfile: UserProfile;
 	export let published: boolean;
 	export let onDataChange: () => void = () => {};
 
@@ -71,11 +73,11 @@
 </script>
 
 <div class="my-4 w-full overflow-x-auto">
-	<table class="table-zebra table w-full px-4">
+	<table class="table table-zebra w-full px-4">
 		<!-- head -->
 		<thead>
 			<tr>
-				<th>ID</th>
+				<th>Slug/ID</th>
 				<th>Cover</th>
 				<th>Title</th>
 				<th>Summary</th>
@@ -89,7 +91,13 @@
 					<td>
 						{#if published}
 							<!-- IF PUBLISH STATUS IS TRUE, SET THE ID AS LINK -->
-							<a href={`/blog/${item.ID}`} class="text-sm hover:underline">{item.ID}</a>
+							<a
+								href={`/blog/${userProfile.Username}/${item.Slug}`}
+								class="text-sm hover:underline"
+								title={item.Slug}
+							>
+								{item.Slug.length > 20 ? item.Slug.substring(0, 20) + '...' : item.Slug}
+							</a>
 						{:else}
 							<!-- OTHERWISE, SET AS A PREVIEW LINK -->
 							<a href={`/blog/preview/${item.ID}`} class="text-sm hover:underline">{item.ID}</a>
@@ -125,9 +133,10 @@
 						{#if published}
 							<div class="flex gap-1">
 								<button
-									on:click={() => (window.location.href = `/blog/${item.ID}`)}
+									on:click={() =>
+										(window.location.href = `/blog/${userProfile.Username}/${item.Slug}`)}
 									title="See Details"
-									class="btn-info btn-sm btn text-sm"
+									class="btn btn-info btn-sm text-sm"
 								>
 									<svg
 										xmlns="http://www.w3.org/2000/svg"
@@ -157,7 +166,7 @@
 										actionModal = true;
 									}}
 									title="Edit Blog"
-									class="btn-warning btn-sm btn text-sm"
+									class="btn btn-warning btn-sm text-sm"
 								>
 									<svg
 										xmlns="http://www.w3.org/2000/svg"
@@ -182,7 +191,7 @@
 										actionModal = true;
 									}}
 									title="Unpublish Blog"
-									class="btn-error btn-sm btn text-sm"
+									class="btn btn-error btn-sm text-sm"
 								>
 									<svg
 										xmlns="http://www.w3.org/2000/svg"
@@ -209,7 +218,7 @@
 										actionModal = true;
 									}}
 									title="Publish Blog"
-									class="btn-primary btn-sm btn text-sm"
+									class="btn btn-primary btn-sm text-sm"
 								>
 									<svg
 										xmlns="http://www.w3.org/2000/svg"
@@ -234,7 +243,7 @@
 										actionModal = true;
 									}}
 									title="Edit Blog"
-									class="btn-warning btn-sm btn text-sm"
+									class="btn btn-warning btn-sm text-sm"
 								>
 									<svg
 										xmlns="http://www.w3.org/2000/svg"
@@ -259,7 +268,7 @@
 										actionModal = true;
 									}}
 									title="Remove Blog"
-									class="btn-error disabled btn-sm btn text-sm"
+									class="btn disabled btn-error btn-sm text-sm"
 									disabled
 								>
 									<svg

--- a/src/routes/blog/[author]/[slug]/+error.svelte
+++ b/src/routes/blog/[author]/[slug]/+error.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { themeChange } from 'theme-change';
-	import MetaHead from '../../../components/meta/MetaHead.svelte';
+	import MetaHead from '../../../../components/meta/MetaHead.svelte';
 
 	// Mount saved theme from local storage
 	onMount(async () => {

--- a/src/routes/blog/[author]/[slug]/+page.server.ts
+++ b/src/routes/blog/[author]/[slug]/+page.server.ts
@@ -1,16 +1,17 @@
 import { SERVER_URL } from '$env/static/private';
 import { error, type ServerLoadEvent } from '@sveltejs/kit';
-import type UserProfile from '../../../types/UserProfile';
-import parseMD from '../../../libs/ParseMarkdown';
+import type UserProfile from '../../../../types/UserProfile';
+import parseMD from '../../../../libs/ParseMarkdown';
 
 export async function load({ fetch, params }: ServerLoadEvent) {
-	let blogID = params.slug;
+	let author = params.author;
+	let slug = params.slug;
 	let userProfile: UserProfile | null = null;
 
 	try {
 		const [userReq, blogReq] = await Promise.allSettled([
 			fetch(`${SERVER_URL}/user/profile`),
-			fetch(`${SERVER_URL}/blog/get/${blogID}`)
+			fetch(`${SERVER_URL}/blog/get/${author}/${slug}`)
 		]);
 
 		// if request status is not 200 (OK)

--- a/src/routes/blog/[author]/[slug]/+page.svelte
+++ b/src/routes/blog/[author]/[slug]/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-	import type { PageData } from '../../../../.svelte-kit/types/src/routes/blog/[slug]/$types';
-	import type { ISafeBlogAuthor } from '../../../types/Blog';
+	import type { PageData } from './$types';
+	import type { ISafeBlogAuthor } from '../../../../types/Blog';
 	import { onMount } from 'svelte';
 	import { themeChange } from 'theme-change';
-	import type UserProfile from '../../../types/UserProfile';
-	import DetailBlogBody from '../../../components/body/DetailBlogBody.svelte';
-	import MainHeader from '../../../components/header/MainHeader.svelte';
-	import MetaHead from '../../../components/meta/MetaHead.svelte';
-	import SchemaHead from '../../../components/meta/SchemaHead.svelte';
+	import type UserProfile from '../../../../types/UserProfile';
+	import DetailBlogBody from '../../../../components/body/DetailBlogBody.svelte';
+	import MainHeader from '../../../../components/header/MainHeader.svelte';
+	import MetaHead from '../../../../components/meta/MetaHead.svelte';
+	import SchemaHead from '../../../../components/meta/SchemaHead.svelte';
 
 	export let data: PageData;
 
@@ -28,7 +28,7 @@
 <!-- META TAGs -->
 <MetaHead
 	title={`${blog.Title} by ${blog.Author.Username} | Blog | Resqiar.com`}
-	url={`https://resqiar.com/blog/${blog.ID}`}
+	url={`https://resqiar.com/blog/${blog.Author.Username}/${blog.Slug}`}
 	description={blog.Summary}
 	imageURL={blog.CoverURL}
 />

--- a/src/routes/blog/manage/+page.svelte
+++ b/src/routes/blog/manage/+page.svelte
@@ -48,5 +48,11 @@
 	<MainHeader active={1} user={profile} />
 
 	<!-- Body -->
-	<ManageBlogBody {publishedBlogs} {draftedBlogs} {error} onDataChange={handleDataChange} />
+	<ManageBlogBody
+		userProfile={profile}
+		{publishedBlogs}
+		{draftedBlogs}
+		{error}
+		onDataChange={handleDataChange}
+	/>
 </header>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -3,7 +3,7 @@ import type { ServerLoadEvent } from '@sveltejs/kit';
 
 export async function GET({ fetch }: ServerLoadEvent) {
 	try {
-		const req = await fetch(`${PUBLIC_SERVER_URL}/blog/list/id`);
+		const req = await fetch(`${PUBLIC_SERVER_URL}/blog/list/slug`);
 		if (!req.ok) return;
 
 		const { result } = await req.json();
@@ -13,26 +13,26 @@ export async function GET({ fetch }: ServerLoadEvent) {
         <url>
             <loc>https://resqiar.com</loc>
             <changefreq>weekly</changefreq>
-            <priority>0.9</priority>
+            <priority>0.8</priority>
         </url>
 
         <url>
             <loc>https://resqiar.com/blog</loc>
             <changefreq>weekly</changefreq>
-            <priority>0.9</priority>
+            <priority>0.8</priority>
         </url>
 
         ${result
-					.map((data: { ID: string; UpdatedAt: string }) => {
-						return `
+				.map((data: { AuthorUsername: string; Slug: string; UpdatedAt: string }) => {
+					return `
                 <url>
-                    <loc>https://resqiar.com/blog/${data.ID}</loc>
-                    <changefreq>weekly</changefreq>
+                    <loc>https://resqiar.com/blog/${data.AuthorUsername}/${data.Slug}</loc>
+                    <changefreq>daily</changefreq>
                     <lastmod>${data.UpdatedAt}</lastmod>
-                    <priority>0.8</priority>
+                    <priority>0.9</priority>
                 </url>`;
-					})
-					.join('')}
+				})
+				.join('')}
     </urlset>`;
 
 		return new Response(xml, {

--- a/src/types/Blog.ts
+++ b/src/types/Blog.ts
@@ -2,6 +2,7 @@ import type { ISafeUser } from './UserProfile';
 
 export interface IBlog {
 	ID: string;
+	Slug: string;
 	CreatedAt: string;
 	UpdatedAt: string;
 	PublishedAt: string;
@@ -16,6 +17,7 @@ export interface IBlog {
 
 export interface ISafeBlog {
 	ID: string;
+	Slug: string;
 	CreatedAt: string;
 	PublishedAt: string;
 	UpdatedAt: string;


### PR DESCRIPTION
This PR reflects what change in server as of https://github.com/resqiar/resqiar.com-server/commit/b80fad3a8083af44e0cbd6bfabeb74547431e6d2

- [x] Change sitemap to use slug instead of ID
- [x] Change blog card URL to `/blog/{author}/{slug}`
- [x] Change manage blog table to use slug version when published, and keep using ID when drafted.