### PR TITLE
Ability to fill the content editor with file reading

### DIFF
--- a/src/components/body/CreateBlogBody.svelte
+++ b/src/components/body/CreateBlogBody.svelte
@@ -2,7 +2,7 @@
 	import { fade } from 'svelte/transition';
 	import { handleBlogCreate } from '../../libs/CreateBlog';
 	import ConfirmationModal from '../modal/ConfirmationModal.svelte';
-	import ImageDropzone from '../others/ImageDropzone.svelte';
+	import FileDropzone from '../others/FileDropzone.svelte';
 
 	let title: string = '';
 	let summary: string = '';
@@ -43,6 +43,8 @@
 		// displaying a success message.
 		if (id) return (window.location.href = '/blog/manage');
 	}
+
+	function handleMD(file: File) {}
 </script>
 
 <main class="mb-32 px-4 py-8 lg:px-24">
@@ -73,7 +75,7 @@
 								preview = null;
 							}}
 							title="Discard Image"
-							class="btn-sm btn-circle btn"
+							class="btn btn-circle btn-sm"
 						>
 							<svg
 								xmlns="http://www.w3.org/2000/svg"
@@ -103,7 +105,13 @@
 					</div>
 				{:else}
 					<!-- IMAGE FILE DROPZONE -->
-					<ImageDropzone onDropSuccess={(file) => (imageFile = file)} />
+					<FileDropzone
+						title="Click or Drag Image Here"
+						subTitle="Supported formats are jpg, jpeg, png"
+						acceptFiles={['image/jpg', 'image/jpeg', 'image/png']}
+						onDropSuccess={(file) => (imageFile = file)}
+						customClass="flex flex-col items-center justify-center min-h-[300px] rounded-lg bg-base-300"
+					/>
 				{/if}
 			</div>
 
@@ -117,7 +125,7 @@
 					id="title-input"
 					type="text"
 					placeholder="e.g The Programmer Story: Hello World"
-					class="input-bordered input w-full"
+					class="input input-bordered w-full"
 					maxlength={100}
 				/>
 				<label class="label" for="title-input">
@@ -133,7 +141,7 @@
 				</div>
 				<textarea
 					bind:value={summary}
-					class="textarea-bordered textarea"
+					class="textarea textarea-bordered"
 					placeholder="e.g The Programmer Story: Hello World follows Alex, a skilled programmer, on a transformative journey. Alex creates an AI program named Hello World that simulates human emotions. As the program evolves, Alex realizes its immense potential..."
 					maxlength={300}
 				/>
@@ -145,6 +153,21 @@
 			<div>
 				<div class="mx-1 my-2">
 					<h2 class="font-semibold">Blog Content</h2>
+				</div>
+
+				<div class="mx-1 my-4 mb-8 flex flex-col gap-6">
+					<p>Do you want to directly fill using Markdown file? Upload them here.</p>
+
+					<!-- Markdown FILE DROPZONE -->
+					<FileDropzone
+						title="Click or drag markdown file here"
+						subTitle="Supported format is only .md file"
+						acceptFiles={['text/markdown']}
+						onDropSuccess={handleMD}
+						customClass="px-12 flex flex-col items-center justify-center w-fit min-h-[80px] rounded-lg bg-base-300"
+					/>
+
+					<p>Otherwise, you can use our online editor below.</p>
 				</div>
 
 				<!-- CONTENT EDITOR COMPONENT -->
@@ -195,7 +218,7 @@
 						<div>
 							<label
 								for="create-as-draft-modal"
-								class="btn-sm btn w-full gap-2 rounded-full text-sm font-normal normal-case"
+								class="btn btn-sm w-full gap-2 rounded-full text-sm font-normal normal-case"
 							>
 								Create as <span class="font-semibold text-amber-300">Draft</span>
 							</label>

--- a/src/components/body/CreateBlogBody.svelte
+++ b/src/components/body/CreateBlogBody.svelte
@@ -39,12 +39,19 @@
 		});
 
 		// for now just redirect to manage blog when creating only a draft
-		// in the future, it is a good way to handle successful with
 		// displaying a success message.
 		if (id) return (window.location.href = '/blog/manage');
 	}
 
-	function handleMD(file: File) {}
+	function handleMD(file: File) {
+		const reader = new FileReader();
+		reader.addEventListener('load', (event) => {
+			const result = event.target?.result as string;
+			if (result !== null && result !== '') return (content = result);
+		});
+
+		reader.readAsText(file);
+	}
 </script>
 
 <main class="mb-32 px-4 py-8 lg:px-24">
@@ -161,8 +168,8 @@
 					<!-- Markdown FILE DROPZONE -->
 					<FileDropzone
 						title="Click or drag markdown file here"
-						subTitle="Supported format is only .md file"
-						acceptFiles={['text/markdown']}
+						subTitle="The supported formats are only .md and .txt"
+						acceptFiles={['text/markdown', 'text/plain']}
 						onDropSuccess={handleMD}
 						customClass="px-12 flex flex-col items-center justify-center w-fit min-h-[80px] rounded-lg bg-base-300"
 					/>

--- a/src/components/body/EditBlogBody.svelte
+++ b/src/components/body/EditBlogBody.svelte
@@ -3,7 +3,7 @@
 	import { handleBlogUpdate } from '../../libs/UpdateBlog';
 	import type { ISafeBlogAuthor } from '../../types/Blog';
 	import ConfirmationModal from '../modal/ConfirmationModal.svelte';
-	import ImageDropzone from '../others/ImageDropzone.svelte';
+	import FileDropzone from '../others/FileDropzone.svelte';
 
 	export let blog: ISafeBlogAuthor;
 
@@ -48,6 +48,16 @@
 		// displaying a success message.
 		if (success) return (window.location.href = '/blog/manage');
 	}
+
+	function handleMD(file: File) {
+		const reader = new FileReader();
+		reader.addEventListener('load', (event) => {
+			const result = event.target?.result as string;
+			if (result !== null && result !== '') return (content = result);
+		});
+
+		reader.readAsText(file);
+	}
 </script>
 
 <main class="mb-32 px-4 py-8 lg:px-24">
@@ -84,7 +94,7 @@
 								preview = null;
 							}}
 							title="Discard Image"
-							class="btn-sm btn-circle btn"
+							class="btn btn-circle btn-sm"
 						>
 							<svg
 								xmlns="http://www.w3.org/2000/svg"
@@ -108,7 +118,7 @@
 								preview = blog.CoverURL;
 							}}
 							title="Restore Image"
-							class="btn-sm btn-circle btn"
+							class="btn btn-circle btn-sm"
 						>
 							<svg
 								xmlns="http://www.w3.org/2000/svg"
@@ -139,7 +149,13 @@
 					</div>
 				{:else}
 					<!-- IMAGE FILE DROPZONE -->
-					<ImageDropzone onDropSuccess={(file) => (imageFile = file)} />
+					<FileDropzone
+						title="Click or Drag Image Here"
+						subTitle="Supported formats are jpg, jpeg, png"
+						acceptFiles={['image/jpg', 'image/jpeg', 'image/png']}
+						onDropSuccess={(file) => (imageFile = file)}
+						customClass="flex flex-col items-center justify-center min-h-[300px] rounded-lg bg-base-300"
+					/>
 				{/if}
 			</div>
 
@@ -153,7 +169,7 @@
 					id="title-input"
 					type="text"
 					placeholder="e.g The Programmer Story: Hello World"
-					class="input-bordered input w-full"
+					class="input input-bordered w-full"
 					maxlength={100}
 				/>
 				<label class="label" for="title-input">
@@ -169,7 +185,7 @@
 				</div>
 				<textarea
 					bind:value={summary}
-					class="textarea-bordered textarea"
+					class="textarea textarea-bordered"
 					placeholder="e.g The Programmer Story: Hello World follows Alex, a skilled programmer, on a transformative journey. Alex creates an AI program named Hello World that simulates human emotions. As the program evolves, Alex realizes its immense potential..."
 					maxlength={300}
 				/>
@@ -181,6 +197,21 @@
 			<div>
 				<div class="mx-1 my-2">
 					<h2 class="font-semibold">Blog Content</h2>
+				</div>
+
+				<div class="mx-1 my-4 mb-8 flex flex-col gap-6">
+					<p>Do you want to directly fill using Markdown file? Upload them here.</p>
+
+					<!-- Markdown FILE DROPZONE -->
+					<FileDropzone
+						title="Click or drag markdown file here"
+						subTitle="The supported formats are only .md and .txt"
+						acceptFiles={['text/markdown', 'text/plain']}
+						onDropSuccess={handleMD}
+						customClass="px-12 flex flex-col items-center justify-center w-fit min-h-[80px] rounded-lg bg-base-300"
+					/>
+
+					<p>Otherwise, you can use our online editor below.</p>
 				</div>
 
 				<!-- CONTENT EDITOR COMPONENT -->
@@ -231,7 +262,7 @@
 						<div>
 							<label
 								for="update-modal"
-								class="btn-sm btn w-full gap-2 rounded-full text-sm font-normal normal-case"
+								class="btn btn-sm w-full gap-2 rounded-full text-sm font-normal normal-case"
 							>
 								<span class="font-semibold text-amber-300">Save Update</span>
 							</label>

--- a/src/components/others/FileDropzone.svelte
+++ b/src/components/others/FileDropzone.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import Dropzone from 'svelte-file-dropzone/Dropzone.svelte';
 
+	export let title: string = '';
+	export let subTitle: string = '';
+	export let customClass: string = '';
+	export let acceptFiles: string[] = [];
+
 	let onDragHover: boolean = false;
 	let fileError: boolean = false;
 
@@ -29,13 +34,13 @@
 	on:dragleave={() => (onDragHover = false)}
 	disableDefaultStyles={true}
 	multiple={false}
-	accept={['image/jpg', 'image/jpeg', 'image/png']}
+	accept={acceptFiles}
 	containerClasses={`${
 		onDragHover ? 'border-2 border-amber-500 border-dashed' : ''
-	} flex flex-col items-center justify-center min-h-[300px] rounded-lg bg-base-300`}
+	} ${customClass}`}
 >
-	<p class="font-semibold">Click or Drag Image Here</p>
-	<p class="text-sm">Supported formats are jpg, jpeg, png</p>
+	<p class="font-semibold">{title}</p>
+	<p class="text-sm">{subTitle}</p>
 
 	{#if fileError}
 		<p class="text-sm text-red-500">


### PR DESCRIPTION
Just as the name, this PR contains the code to add a Drag & Drop zone — which accepts .md and .txt file — to automatically fill the editor with the content inside that file.